### PR TITLE
fix flaky test

### DIFF
--- a/test/p1Settlement.test.ts
+++ b/test/p1Settlement.test.ts
@@ -194,7 +194,7 @@ perpetualDescribe('P1Settlement', init, (ctx: ITestContext) => {
     });
 
     it('Does not settle an account if its local index is up-to-date', async () => {
-      await ctx.perpetual.testing.funder.setFunding(new BaseValue('0.05'));
+      await ctx.perpetual.testing.funder.setFunding(new BaseValue('-0.05'));
 
       // Wait until we get two deposits with the same timestamp.
       let result1: TxResult;


### PR DESCRIPTION
Interest was sometimes accruing too negatively for the account, making it have negative collateralization which caused reverts