### PR TITLE
v0.2.5: Fix Send/Call/Estimate Options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/perpetual",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/perpetual",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Perpetual Contracts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -115,13 +115,16 @@ export interface TxResult {
 
 export interface TxOptions {
   from?: address;
-  gasPrice?: number | string;
-  gas?: number;
   value?: number | string;
 }
 
-export interface SendOptions extends TxOptions {
+export interface NativeSendOptions extends TxOptions {
+  gasPrice?: number | string;
+  gas?: number | string;
   nonce?: string | number;
+}
+
+export interface SendOptions extends NativeSendOptions {
   confirmations?: number;
   confirmationType?: ConfirmationType;
   gasMultiplier?: number;

--- a/src/modules/Contracts.ts
+++ b/src/modules/Contracts.ts
@@ -174,7 +174,7 @@ export class Contracts {
       ...this.defaultOptions,
       ...specificOptions,
     });
-    return (method as any).call(otherOptions, blockNumber);
+    return (method as any).call(otherOptions, blockNumber || 'latest');
   }
 
   public async send(
@@ -368,33 +368,33 @@ export class Contracts {
   // ============ Parse Options ============
 
   private toEstimateOptions(
-    txOptions: SendOptions,
+    options: SendOptions,
   ): TxOptions {
-    return {
-      from: txOptions.from,
-      value: txOptions.value,
-    };
+    return _.pick(options, [
+      'from',
+      'value',
+    ]);
   }
 
   private toCallOptions(
     options: any,
   ): CallOptions {
-    return {
-      from: options.from,
-      value: options.value,
-      blockNumber: options.blockNumber,
-    };
+    return _.pick(options, [
+      'from',
+      'value',
+      'blockNumber',
+    ]);
   }
 
   private toNativeSendOptions(
     options: any,
   ): NativeSendOptions {
-    return {
-      from: options.from,
-      value: options.value,
-      gasPrice: options.gasPrice,
-      gas: options.gas,
-      nonce: options.nonce,
-    };
+    return _.pick(options, [
+      'from',
+      'value',
+      'gasPrice',
+      'gas',
+      'nonce',
+    ]);
   }
 }

--- a/src/modules/Contracts.ts
+++ b/src/modules/Contracts.ts
@@ -29,12 +29,13 @@ import {
 
 import {
   address,
-  CallOptions,
   ConfirmationType,
   Provider,
-  SendOptions,
-  TxOptions,
   TxResult,
+  TxOptions,
+  CallOptions,
+  NativeSendOptions,
+  SendOptions,
 } from '../lib/types';
 
 // JSON
@@ -168,17 +169,12 @@ export class Contracts {
   ): Promise<any> {
     const {
       blockNumber,
-      confirmations,
-      confirmationType,
-      gasMultiplier,
-      gas, // don't send gas
-      gasPrice, // don't send gasPrice
       ...otherOptions
-    } = {
+    } = this.toCallOptions({
       ...this.defaultOptions,
       ...specificOptions,
-    };
-    return (method as any).call(otherOptions);
+    });
+    return (method as any).call(otherOptions, blockNumber);
   }
 
   public async send(
@@ -240,9 +236,8 @@ export class Contracts {
       confirmations,
       confirmationType,
       gasMultiplier,
-      ...remainingOptions
+      ...txOptions
     } = sendOptions;
-    const txOptions = remainingOptions as TxOptions;
 
     if (!Object.values(ConfirmationType).includes(confirmationType)) {
       throw new Error(`Invalid confirmation type: ${confirmationType}`);
@@ -260,7 +255,7 @@ export class Contracts {
       }
     }
 
-    const promi: PromiEvent<Contract> = method.send(txOptions as any);
+    const promi: PromiEvent<Contract> = method.send(this.toNativeSendOptions(txOptions) as any);
 
     let hashOutcome = OUTCOMES.INITIAL;
     let confirmationOutcome = OUTCOMES.INITIAL;
@@ -356,18 +351,50 @@ export class Contracts {
     method: ContractSendMethod,
     txOptions: SendOptions,
   ) {
+    const estimateOptions: TxOptions = this.toEstimateOptions(txOptions);
     try {
-      const gasEstimate = await method.estimateGas(txOptions);
+      const gasEstimate = await method.estimateGas(estimateOptions);
       return gasEstimate;
     } catch (error) {
-      const { from, value } = txOptions;
       error.transactionData = {
-        from,
-        value,
+        ...estimateOptions,
         data: method.encodeABI(),
         to: (method as any)._parent._address,
       };
       throw error;
     }
+  }
+
+  // ============ Parse Options ============
+
+  private toEstimateOptions(
+    txOptions: SendOptions,
+  ): TxOptions {
+    return {
+      from: txOptions.from,
+      value: txOptions.value,
+    };
+  }
+
+  private toCallOptions(
+    options: any,
+  ): CallOptions {
+    return {
+      from: options.from,
+      value: options.value,
+      blockNumber: options.blockNumber,
+    };
+  }
+
+  private toNativeSendOptions(
+    options: any,
+  ): NativeSendOptions {
+    return {
+      from: options.from,
+      value: options.value,
+      gasPrice: options.gasPrice,
+      gas: options.gas,
+      nonce: options.nonce,
+    };
   }
 }


### PR DESCRIPTION
Instead of blacklisting options passed to web3 for send/call/estimateGas, explicitly whitelist fields we allow through.

Also fixes a bug where we were not using `blockNumber` during `eth_call`