### PR TITLE
Loosen funding rate bounds

### DIFF
--- a/contracts/protocol/v1/oracles/P1FundingOracle.sol
+++ b/contracts/protocol/v1/oracles/P1FundingOracle.sol
@@ -56,17 +56,15 @@ contract P1FundingOracle is
      * @notice Bounding params constraining updates to the funding rate.
      *
      *  Like the funding rate, these are per-second rates, fixed-point with 18 decimals.
-     *  We calculate the per-second rates from the market specifications, which uses 8-hour rates:
+     *  We calculate the per-second rates from the market specifications, which use 8-hour rates:
      *  - The max absolute funding rate is 0.75% (8-hour rate).
-     *  - The max change in a single update is 0.75% (8-hour rate).
-     *  - The max change over a 55-minute period is 0.75% (8-hour rate).
+     *  - The max change over a 45-minute period is 1.5% (8-hour rate).
      *
-     *  This means the fastest the funding rate can go from zero to its min or max allowed value
-     *  (or vice versa) is in 55 minutes.
+     *  This means the fastest the funding rate can go from its min to its max value, or vice versa,
+     *  is in 45 minutes.
      */
     uint128 public constant MAX_ABS_VALUE = BASE * 75 / 10000 / (8 hours);
-    uint128 public constant MAX_ABS_DIFF_PER_UPDATE = MAX_ABS_VALUE;
-    uint128 public constant MAX_ABS_DIFF_PER_SECOND = MAX_ABS_VALUE / (55 minutes);
+    uint128 public constant MAX_ABS_DIFF_PER_SECOND = MAX_ABS_VALUE * 2 / (45 minutes);
 
     // ============ Events ============
 
@@ -197,10 +195,7 @@ contract P1FundingOracle is
 
         // Get the maximum allowed change in the rate.
         uint256 timeDelta = block.timestamp.sub(oldRateWithTimestamp.timestamp);
-        uint256 maxDiff = Math.min(
-            MAX_ABS_DIFF_PER_UPDATE,
-            MAX_ABS_DIFF_PER_SECOND.mul(timeDelta)
-        );
+        uint256 maxDiff = MAX_ABS_DIFF_PER_SECOND.mul(timeDelta);
 
         // Calculate and return the bounded rate.
         if (newRate.gt(oldRate)) {

--- a/src/lib/Constants.ts
+++ b/src/lib/Constants.ts
@@ -83,12 +83,11 @@ export const ORDER_FLAGS = {
 
 // ============ P1FundingOracle.sol ============
 
-// Rate limiting is based on a 55 minute period, equal to the funding rate update interval
-// of one hour, with five minutes as a buffer.
-const FUNDING_LIMIT_PERIOD = INTEGERS.ONE_MINUTE_IN_SECONDS.times(55);
+// Rate limiting is based on a 45 minute period, equal to the funding rate update interval
+// of one hour, with fifteen minutes as a buffer.
+const FUNDING_LIMIT_PERIOD = INTEGERS.ONE_MINUTE_IN_SECONDS.times(45);
 
 // Funding rate limits set by the smart contract.
 export const FUNDING_RATE_MAX_ABS_VALUE = FundingRate.fromEightHourRate('0.0075').roundedDown();
-export const FUNDING_RATE_MAX_ABS_DIFF_PER_UPDATE = FUNDING_RATE_MAX_ABS_VALUE;
 export const FUNDING_RATE_MAX_ABS_DIFF_PER_SECOND =
-  FUNDING_RATE_MAX_ABS_VALUE.div(FUNDING_LIMIT_PERIOD).roundedDown();
+  FUNDING_RATE_MAX_ABS_VALUE.times(2).div(FUNDING_LIMIT_PERIOD).roundedDown();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -172,7 +172,6 @@ export interface TradeResult {
 
 export interface FundingRateBounds {
   maxAbsValue: FundingRate;
-  maxAbsDiffPerUpdate: FundingRate;
   maxAbsDiffPerSecond: FundingRate;
 }
 

--- a/src/modules/FundingOracle.ts
+++ b/src/modules/FundingOracle.ts
@@ -49,21 +49,17 @@ export class FundingOracle {
   public async getBounds(
     options?: CallOptions,
   ): Promise<FundingRateBounds> {
-    const results: [string, string, string] = await Promise.all([
+    const results: [string, string] = await Promise.all([
       this.contracts.call(this.contracts.p1FundingOracle.methods.MAX_ABS_VALUE(), options),
-      this.contracts.call(
-        this.contracts.p1FundingOracle.methods.MAX_ABS_DIFF_PER_UPDATE(),
-        options,
-      ),
       this.contracts.call(
         this.contracts.p1FundingOracle.methods.MAX_ABS_DIFF_PER_SECOND(),
         options,
       ),
     ]);
-    const [maxAbsValue, maxAbsDiffPerUpdate, maxAbsDiffPerSecond] = results.map((s: string) => {
+    const [maxAbsValue, maxAbsDiffPerSecond] = results.map((s: string) => {
       return FundingRate.fromSolidity(s);
     });
-    return { maxAbsValue, maxAbsDiffPerUpdate, maxAbsDiffPerSecond };
+    return { maxAbsValue, maxAbsDiffPerSecond };
   }
 
   public async getFunding(

--- a/test/p1FundingOracle.test.ts
+++ b/test/p1FundingOracle.test.ts
@@ -1,6 +1,5 @@
 import {
   FUNDING_RATE_MAX_ABS_VALUE,
-  FUNDING_RATE_MAX_ABS_DIFF_PER_UPDATE,
   FUNDING_RATE_MAX_ABS_DIFF_PER_SECOND,
   INTEGERS,
 } from '../src/lib/Constants';
@@ -44,7 +43,6 @@ perpetualDescribe('P1FundingOracle', init, (ctx: ITestContext) => {
     it('the bounds are set as expected', async () => {
       const bounds = await ctx.perpetual.fundingOracle.getBounds();
       expectBaseValueEqual(bounds.maxAbsValue, FUNDING_RATE_MAX_ABS_VALUE);
-      expectBaseValueEqual(bounds.maxAbsDiffPerUpdate, FUNDING_RATE_MAX_ABS_DIFF_PER_UPDATE);
       expectBaseValueEqual(bounds.maxAbsDiffPerSecond, FUNDING_RATE_MAX_ABS_DIFF_PER_SECOND);
     });
   });
@@ -190,36 +188,6 @@ perpetualDescribe('P1FundingOracle', init, (ctx: ITestContext) => {
         await setFundingRate(
           minFundingRate.minus(minUnit),
           { expectedRate: minFundingRate },
-        );
-      });
-
-      it('cannot increase faster than the per update limit', async () => {
-        // Start at the min rate.
-        await setFundingRate(FUNDING_RATE_MAX_ABS_VALUE.negated());
-
-        // Incrase by the max-update amount, twice.
-        await setFundingRate(
-          FUNDING_RATE_MAX_ABS_VALUE,
-          { expectedRate: new FundingRate(0) },
-        );
-        await setFundingRate(
-          FUNDING_RATE_MAX_ABS_VALUE,
-          { expectedRate: FUNDING_RATE_MAX_ABS_VALUE },
-        );
-      });
-
-      it('cannot decrease faster than the per update limit', async () => {
-        // Start at the max rate.
-        await setFundingRate(FUNDING_RATE_MAX_ABS_VALUE);
-
-        // Decrease by the max-update amount, twice.
-        await setFundingRate(
-          FUNDING_RATE_MAX_ABS_VALUE.negated(),
-          { expectedRate: new FundingRate(0) },
-        );
-        await setFundingRate(
-          FUNDING_RATE_MAX_ABS_VALUE.negated(),
-          { expectedRate: FUNDING_RATE_MAX_ABS_VALUE.negated() },
         );
       });
 


### PR DESCRIPTION
Effect: Remove the per-update bound and loosen the per-second bound.

Why
* Make it easier to predict the outcome of rate updates.
* Removing unnecessary bounds may make the effect of funding on the market more efficient.

There are two main considerations in the bounds design:
1. General funding rate design and trader experience.
2. Decentralization and smart contract security.

The per-update bound was originally implemented based on BitMEX. Based on my research on funding rates and comparison with centralized exchanges, I don't think these two bounds are very meaningful with respect to (1). I don't think the per-update bound is relevant to (2). The per-second bound could potentially be important from a decentralization or security perspective to prevent certain types of abuse by the funding rate setter or perpetual admin.